### PR TITLE
Add completed default and validation

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,3 @@
 class Task < ApplicationRecord
+  validates :title, presence: true
 end

--- a/db/migrate/20250527104811_create_tasks.rb
+++ b/db/migrate/20250527104811_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration[7.1]
     create_table :tasks do |t|
       t.string :title
       t.text :details
-      t.boolean :completed
+      t.boolean :completed, default: false
 
       t.timestamps
     end

--- a/db/migrate/20250611225408_add_default_to_completed_in_tasks.rb
+++ b/db/migrate/20250611225408_add_default_to_completed_in_tasks.rb
@@ -1,0 +1,5 @@
+class AddDefaultToCompletedInTasks < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :tasks, :completed, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_27_104811) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_11_225408) do
   create_table "tasks", force: :cascade do |t|
     t.string "title"
     t.text "details"
-    t.boolean "completed"
+    t.boolean "completed", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
## Summary
- set `completed` default to false in tasks migration
- add `title` presence validation
- add migration to change existing column default
- run DB migrations

## Testing
- `rails db:migrate`
- `rails test`

------
https://chatgpt.com/codex/tasks/task_e_684a08bdf0e88329b395da3d54d255c9