### PR TITLE
Add task validations and CRUD tests

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,9 +1,50 @@
 class TasksController < ApplicationController
+  before_action :set_task, only: %i[show edit update destroy]
+
   def index
     @tasks = Task.all
   end
 
   def show
+  end
+
+  def new
+    @task = Task.new
+  end
+
+  def edit
+  end
+
+  def create
+    @task = Task.new(task_params)
+
+    if @task.save
+      redirect_to @task, notice: "Task was successfully created."
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @task.update(task_params)
+      redirect_to @task, notice: "Task was successfully updated."
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @task.destroy
+    redirect_to tasks_url, notice: "Task was successfully destroyed."
+  end
+
+  private
+
+  def set_task
     @task = Task.find(params[:id])
+  end
+
+  def task_params
+    params.require(:task).permit(:title, :details, :completed)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,4 @@
 class Task < ApplicationRecord
+  validates :title, presence: true
+  validates :details, presence: true
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Edit Task</h1>
+<%= form_with(model: @task, local: true) do |form| %>
+  <%= form.label :title %>
+  <%= form.text_field :title %>
+  <%= form.label :details %>
+  <%= form.text_area :details %>
+  <%= form.label :completed %>
+  <%= form.check_box :completed %>
+  <%= form.submit %>
+<% end %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,10 @@
+<h1>New Task</h1>
+<%= form_with(model: @task, local: true) do |form| %>
+  <%= form.label :title %>
+  <%= form.text_field :title %>
+  <%= form.label :details %>
+  <%= form.text_area :details %>
+  <%= form.label :completed %>
+  <%= form.check_box :completed %>
+  <%= form.submit %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  get "tasks", to: "tasks#index"
-  get "tasks/:id", to: "tasks#show", as: :task
+  resources :tasks
 
   get "up" => "rails/health#show", as: :rails_health_check
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,7 +1,52 @@
 require "test_helper"
 
 class TasksControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @task = tasks(:one)
+  end
+
+  test "should get index" do
+    get tasks_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_task_url
+    assert_response :success
+  end
+
+  test "should create task" do
+    assert_difference("Task.count", 1) do
+      post tasks_url, params: { task: { title: "New Task", details: "Some details", completed: false } }
+    end
+
+    assert_redirected_to task_url(Task.last)
+  end
+
+  test "should show task" do
+    get task_url(@task)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_task_url(@task)
+    assert_response :success
+  end
+
+  test "should update task" do
+    patch task_url(@task), params: { task: { title: "Updated", details: "Updated details", completed: true } }
+    assert_redirected_to task_url(@task)
+    @task.reload
+    assert_equal "Updated", @task.title
+    assert_equal "Updated details", @task.details
+    assert @task.completed
+  end
+
+  test "should destroy task" do
+    assert_difference("Task.count", -1) do
+      delete task_url(@task)
+    end
+
+    assert_redirected_to tasks_url
+  end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,7 +1,20 @@
 require "test_helper"
 
 class TaskTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "valid with all attributes" do
+    task = Task.new(title: "Title", details: "Some details", completed: false)
+    assert task.valid?
+  end
+
+  test "invalid without title" do
+    task = Task.new(details: "Some details", completed: false)
+    assert_not task.valid?
+    assert_includes task.errors[:title], "can't be blank"
+  end
+
+  test "invalid without details" do
+    task = Task.new(title: "Title", completed: false)
+    assert_not task.valid?
+    assert_includes task.errors[:details], "can't be blank"
+  end
 end


### PR DESCRIPTION
## Summary
- validate Task presence of title & details
- implement full CRUD for TasksController
- add routes for resources
- create simple views for new/edit
- add model tests for validations
- add controller tests for CRUD actions

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_684a08c4e5a483299598e8bfc9bf0de9